### PR TITLE
Implement cross-page search, refactor, update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ It supports PDF, XPS, CBZ, EPUB, HTML, and various image formats.
 * Touchpad/Numpad: Scrolling
 * ×: Zoom in
 * ÷: Zoom out
+* Ctrl+R: Reset zoom
 * -: Previous page
 * +: Next page
 * Ctrl+Tab: Go to page

--- a/Screen.cpp
+++ b/Screen.cpp
@@ -21,133 +21,135 @@
 #include <libndls.h>
 #include "Screen.hpp"
 
-namespace Screen {
-	scr_type_t type;
-	unsigned int size;
-	uint8_t *screen;
+bool Screen::initialized;
+unsigned int Screen::size;
+scr_type_t Screen::type;
+uint8_t *Screen::screen;
 
-	bool init() {
-		type = lcd_type() == SCR_320x240_4 ? SCR_320x240_4 : SCR_320x240_565;
-		if (!lcd_init(type))
-			return false;
-		size = (SCREEN_WIDTH*SCREEN_HEIGHT/2) * (type == SCR_320x240_4 ? 1 : 4);
-		screen = new uint8_t[size];
-		return true;
-	}
+Screen::Screen() {
+	if (initialized) throw "Screen is already initialized.";
+	type = lcd_type() == SCR_320x240_4 ? SCR_320x240_4 : SCR_320x240_565;
+	if (!lcd_init(type)) throw "Could not init lcd.";
+	size = (SCREEN_WIDTH*SCREEN_HEIGHT/2) * (type == SCR_320x240_4 ? 1 : 4);
+	screen = new uint8_t[size];
+	initialized = true;
+}
 
-	void deinit() {
+Screen::~Screen() {
+	if (initialized) {
 		delete[] screen;
 		lcd_init(SCR_TYPE_INVALID);
+		initialized = false;
 	}
+}
 
-	void display() {
-		lcd_blit(screen, type);
-	}
+void Screen::display() {
+	lcd_blit(screen, type);
+}
 
-	void setPixel(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y) {
-		// On color models, each pixel is represented in 16-bit high color
-		// On classic models, each pixel is 4 bits grayscale, 0 is black and 15 is white
-		if (x < SCREEN_WIDTH && y < SCREEN_HEIGHT) {
-			unsigned int pos = y * SCREEN_WIDTH + x;
-			if (type == SCR_320x240_565) {
-				reinterpret_cast<uint16_t*>(screen)[pos] = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
-			} else if (pos % 2 == 0) {
-				screen[pos / 2] = (screen[pos / 2] & 0x0F) | (((30 * r + 59 * g + 11 * b) / 100) & 0xF0);
-			} else {
-				screen[pos / 2] = (screen[pos / 2] & 0xF0) | (((30 * r + 59 * g + 11 * b) / 100) >> 4);
-			}
-		}
-	}
-
-	void setPixel(uint8_t c, unsigned int x, unsigned int y) {
-		setPixel(c, c, c, x, y);
-	}
-
-	// The RGBA and GrayA functions display pixmaps with premultiplied alpha. The alpha component is
-	// ignored since we aren't compositing
-
-	void showImgRGB(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
-			unsigned int w, unsigned int h, unsigned int wImg) {
-		unsigned int pos;
-		for (unsigned int i = y1; i < y1 + h; i++) {
-			for (unsigned int j = x1; j < x1 + w; j++) {
-				pos = 3 * (wImg * i + j);
-				setPixel(img[pos], img[pos + 1], img[pos + 2], x0 - x1 + j, y0 - y1 + i);
-			}
-		}
-	}
-
-	void showImgRGBA(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
-			unsigned int w, unsigned int h, unsigned int wImg) {
-		unsigned int pos;
-		for (unsigned int i = y1; i < y1 + h; i++) {
-			for (unsigned int j = x1; j < x1 + w; j++) {
-				pos = 4 * (wImg * i + j);
-				setPixel(img[pos], img[pos + 1], img[pos + 2], x0 - x1 + j, y0 - y1 + i);
-			}
-		}
-	}
-
-	void showImgGray(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
-			unsigned int w, unsigned int h, unsigned int wImg) {
-		unsigned int pos;
-		for (unsigned int i = y1; i < y1 + h; i++) {
-			for (unsigned int j = x1; j < x1 + w; j++) {
-				pos = wImg * i + j;
-				setPixel(img[pos], x0 - x1 + j, y0 - y1 + i);
-			}
-		}
-	}
-
-	void showImgGrayA(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
-			unsigned int w, unsigned int h, unsigned int wImg) {
-		unsigned int pos;
-		for (unsigned int i = y1; i < y1 + h; i++) {
-			for (unsigned int j = x1; j < x1 + w; j++) {
-				pos = 2 * (wImg * i + j);
-				setPixel(img[pos], x0 - x1 + j, y0 - y1 + i);
-			}
-		}
-	}
-
-	void fillScreen(uint8_t r, uint8_t g, uint8_t b) {
-		uint16_t color;
+void Screen::setPixel(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y) {
+	// On color models, each pixel is represented in 16-bit high color
+	// On classic models, each pixel is 4 bits grayscale, 0 is black and 15 is white
+	if (x < SCREEN_WIDTH && y < SCREEN_HEIGHT) {
+		unsigned int pos = y * SCREEN_WIDTH + x;
 		if (type == SCR_320x240_565) {
-			color = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
+			reinterpret_cast<uint16_t*>(screen)[pos] = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
+		} else if (pos % 2 == 0) {
+			screen[pos / 2] = (screen[pos / 2] & 0x0F) | (((30 * r + 59 * g + 11 * b) / 100) & 0xF0);
 		} else {
-			color = (30 * r + 59 * g + 11 * b) / 100;
-			color = (color >> 4) * 0x1111;
-		}
-
-		std::fill(reinterpret_cast<volatile uint16_t*>(screen), reinterpret_cast<volatile uint16_t*>(screen + size), color);
-	}
-
-	void fillScreen(uint8_t c) {
-		fillScreen(c, c, c);
-	}
-
-	void fillRect(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y, unsigned int w,
-			unsigned int h) {
-		for (unsigned int i = x; i < x + w; i++) {
-			for (unsigned int j = y; j < y + h; j++) {
-				setPixel(r, g, b, i, j);
-			}
+			screen[pos / 2] = (screen[pos / 2] & 0xF0) | (((30 * r + 59 * g + 11 * b) / 100) >> 4);
 		}
 	}
+}
 
-	void fillRect(uint8_t c, unsigned int x, unsigned int y, unsigned int w, unsigned int h) {
-		fillRect(c, c, c, x, y, w, h);
+void Screen::setPixel(uint8_t c, unsigned int x, unsigned int y) {
+	setPixel(c, c, c, x, y);
+}
+
+// The RGBA and GrayA functions display pixmaps with premultiplied alpha. The alpha component is
+// ignored since we aren't compositing
+
+void Screen::showImgRGB(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
+		unsigned int w, unsigned int h, unsigned int wImg) {
+	unsigned int pos;
+	for (unsigned int i = y1; i < y1 + h; i++) {
+		for (unsigned int j = x1; j < x1 + w; j++) {
+			pos = 3 * (wImg * i + j);
+			setPixel(img[pos], img[pos + 1], img[pos + 2], x0 - x1 + j, y0 - y1 + i);
+		}
+	}
+}
+
+void Screen::showImgRGBA(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
+		unsigned int w, unsigned int h, unsigned int wImg) {
+	unsigned int pos;
+	for (unsigned int i = y1; i < y1 + h; i++) {
+		for (unsigned int j = x1; j < x1 + w; j++) {
+			pos = 4 * (wImg * i + j);
+			setPixel(img[pos], img[pos + 1], img[pos + 2], x0 - x1 + j, y0 - y1 + i);
+		}
+	}
+}
+
+void Screen::showImgGray(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
+		unsigned int w, unsigned int h, unsigned int wImg) {
+	unsigned int pos;
+	for (unsigned int i = y1; i < y1 + h; i++) {
+		for (unsigned int j = x1; j < x1 + w; j++) {
+			pos = wImg * i + j;
+			setPixel(img[pos], x0 - x1 + j, y0 - y1 + i);
+		}
+	}
+}
+
+void Screen::showImgGrayA(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
+		unsigned int w, unsigned int h, unsigned int wImg) {
+	unsigned int pos;
+	for (unsigned int i = y1; i < y1 + h; i++) {
+		for (unsigned int j = x1; j < x1 + w; j++) {
+			pos = 2 * (wImg * i + j);
+			setPixel(img[pos], x0 - x1 + j, y0 - y1 + i);
+		}
+	}
+}
+
+void Screen::fillScreen(uint8_t r, uint8_t g, uint8_t b) {
+	uint16_t color;
+	if (type == SCR_320x240_565) {
+		color = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
+	} else {
+		color = (30 * r + 59 * g + 11 * b) / 100;
+		color = (color >> 4) * 0x1111;
 	}
 
-	void drawVert(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y, unsigned int h) {
+	std::fill(reinterpret_cast<volatile uint16_t*>(screen), reinterpret_cast<volatile uint16_t*>(screen + size), color);
+}
+
+void Screen::fillScreen(uint8_t c) {
+	fillScreen(c, c, c);
+}
+
+void Screen::fillRect(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y, unsigned int w,
+		unsigned int h) {
+	for (unsigned int i = x; i < x + w; i++) {
 		for (unsigned int j = y; j < y + h; j++) {
-			setPixel(r, g, b, x, j);
+			setPixel(r, g, b, i, j);
 		}
 	}
+}
 
-	void drawHoriz(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y, unsigned int w) {
-		for (unsigned int i = x; i < x + w; i++) {
-			setPixel(r, g, b, i, y);
-		}
+void Screen::fillRect(uint8_t c, unsigned int x, unsigned int y, unsigned int w, unsigned int h) {
+	fillRect(c, c, c, x, y, w, h);
+}
+
+void Screen::drawVert(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y, unsigned int h) {
+	for (unsigned int j = y; j < y + h; j++) {
+		setPixel(r, g, b, x, j);
+	}
+}
+
+void Screen::drawHoriz(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y, unsigned int w) {
+	for (unsigned int i = x; i < x + w; i++) {
+		setPixel(r, g, b, i, y);
 	}
 }

--- a/Screen.hpp
+++ b/Screen.hpp
@@ -21,42 +21,49 @@
 
 #include <cstdint>
 
-namespace Screen {
-	bool init();
 
-	void deinit();
+class Screen {
+	public:
+		Screen();
 
-	void display();
+		~Screen();
 
-	void setPixel(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y);
+		static void display();
 
-	void setPixel(uint8_t c, unsigned int x, unsigned int y);
+		static void setPixel(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y);
 
-	void showImgRGB(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
+		static void setPixel(uint8_t c, unsigned int x, unsigned int y);
+
+		static void showImgRGB(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
 			unsigned int w, unsigned int h, unsigned int wTotal);
 
-	void showImgRGBA(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
+		static void showImgRGBA(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
 			unsigned int w, unsigned int h, unsigned int wTotal);
 
-	void showImgGray(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
+		static void showImgGray(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
 			unsigned int w, unsigned int h, unsigned int wTotal);
 
-	void showImgGrayA(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
+		static void showImgGrayA(uint8_t *img, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
 			unsigned int w, unsigned int h, unsigned int wTotal);
 
-	void fillScreen(uint8_t r, uint8_t g, uint8_t b);
+		static void fillScreen(uint8_t r, uint8_t g, uint8_t b);
 
-	void fillScreen(uint8_t c);
+		static void fillScreen(uint8_t c);
 
-	void fillRect(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y, unsigned int w,
+		static void fillRect(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y, unsigned int w,
 			unsigned int h);
 
-	void fillRect(uint8_t c, unsigned int x, unsigned int y, unsigned int w, unsigned int h);
+		static void fillRect(uint8_t c, unsigned int x, unsigned int y, unsigned int w, unsigned int h);
 
-	void drawVert(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y, unsigned int h);
+		static void drawVert(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y, unsigned int h);
 
-	void drawHoriz(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y, unsigned int w);
+		static void drawHoriz(uint8_t r, uint8_t g, uint8_t b, unsigned int x, unsigned int y, unsigned int w);
 
-}
+	private:
+		static scr_type_t type;
+		static unsigned int size;
+		static uint8_t *screen;
+		static bool initialized;
+};
 
 #endif

--- a/Viewer.cpp
+++ b/Viewer.cpp
@@ -337,22 +337,27 @@ void Viewer::display() {
 
 	// Center it
 	int x = 0, y = 0;
+	// Side fill
 	if (pix->w < width) {
 		x = (width - pix->w) / 2;
 		Screen::fillRect(bgColor, 0, 0, x, height);
 		Screen::fillRect(bgColor, x + pix->w, 0, width - (x + pix->w), height);
 	}
+	// Top/Bottom fill
 	if (pix->h < height) {
 		y = (height - pix->h) / 2;
 		Screen::fillRect(bgColor, 0, 0, width, y);
-		Screen::fillRect(bgColor, y + pix->h, 0, width, height - (y + pix->h));
+		Screen::fillRect(bgColor, 0, y + pix->h, width, height - (y + pix->h));
 	}
+
+	// Content
 	if (has_colors) {
 		Screen::showImgRGBA(pix->samples, x, y, xPos, yPos, std::min(width, pix->w), std::min(height, pix->h), pix->w);
 	} else {
 		Screen::showImgGrayA(pix->samples, x, y, xPos, yPos, std::min(width, pix->w), std::min(height, pix->h), pix->w);
 	}
 
+	// Scroll bars
 	if ((bounds.y1-bounds.y0)>height) {
 		Screen::drawVert(0,0,0,width-1,0,height-4);
 		Screen::drawVert(0,0,0,width-5,0,height-4);
@@ -361,7 +366,6 @@ void Viewer::display() {
 		Screen::fillRect(255,255,255,width-4, 1, 3, height-6);
 		Screen::drawVert(0,0,0,width-3,2+yPos*(height-8)/(bounds.y1-bounds.y0),height*(height-7)/(bounds.y1-bounds.y0));
 	}
-
 	if ((bounds.x1-bounds.x0)>width) {
 		Screen::drawHoriz(0,0,0,0,height-1,width-4);
 		Screen::drawHoriz(0,0,0,0,height-5,width-4);

--- a/Viewer.cpp
+++ b/Viewer.cpp
@@ -277,16 +277,15 @@ int Viewer::getPages() {
 
 void Viewer::fixBounds() {
 	// Make sure we don't go out of bounds
-	if (xPos < 0 || bounds.x1 - bounds.x0 <= width) {
-		xPos = 0;
-	} else if (xPos >= (bounds.x1 - bounds.x0) - std::min(width, static_cast<int>(bounds.x1 - bounds.x0))) {
-		xPos = (bounds.x1 - bounds.x0) - std::min(width, static_cast<int>(bounds.x1 - bounds.x0));
-	}
-	if (yPos < 0 || bounds.y1 - bounds.y0 <= height) {
-		yPos = 0;
-	} else if (yPos >= (bounds.y1 - bounds.y0) - std::min(height, static_cast<int>(bounds.y1 - bounds.y0))) {
-		yPos = (bounds.y1 - bounds.y0) - std::min(height, static_cast<int>(bounds.y1 - bounds.y0));
-	}
+	const int boundsWidth = static_cast<int>(bounds.x1 - bounds.x0);
+	const int boundsHeight = static_cast<int>(bounds.y1 - bounds.y0);
+	const int maxAllowedWidth = boundsWidth - std::min(width, boundsWidth);
+	const int maxAllowedHeight = boundsHeight - std::min(height, boundsHeight);
+	if (xPos < 0 || boundsWidth <= width) xPos = 0;
+	else xPos = std::min(xPos, maxAllowedWidth);
+
+	if (yPos < 0 || boundsHeight <= height) yPos = 0;
+	else yPos = std::min(yPos, maxAllowedHeight);
 }
 
 void Viewer::drawPage() {

--- a/Viewer.cpp
+++ b/Viewer.cpp
@@ -220,7 +220,6 @@ Viewer::Viewer()
 	scale = 1.0f;
 	xPos = 0;
 	yPos = 0;
-	fitWidth = true;
 }
 
 Viewer::~Viewer() {
@@ -301,8 +300,11 @@ void Viewer::drawPage() {
 	fz_page* page = doc->ensureCurrentPageLoaded();
 	bounds = doc->getBounds();
 
-	if (fitWidth) {
-		scale = width / (bounds.x1 - bounds.x0);
+	if (fitSize) {
+		scale = std::min(
+			width / (bounds.x1 - bounds.x0),
+			height / (bounds.y1 - bounds.y0)
+		);
 	}
 
 	fz_scale(&transform, scale, scale);
@@ -414,19 +416,19 @@ void Viewer::scrollRight() {
 	}
 }
 
-void Viewer::setFitWidth() {
-	fitWidth = true;
+void Viewer::setFitSize() {
+	fitSize = true;
 	drawPage();
 }
 
-void Viewer::unsetFitWidth() {
-	fitWidth = false;
+void Viewer::unsetFitSize() {
+	fitSize = false;
 }
 
 void Viewer::zoomIn() {
 	// Try to zoom in on the center
 	if (scale * zoom <= maxScale) {
-		fitWidth = false;
+		fitSize = false;
 		xPos = (xPos + std::min(width, static_cast<int>(bounds.x1 - bounds.x0)) / 2) * zoom;
 		xPos -= std::min(width, static_cast<int>((bounds.x1 - bounds.x0) * zoom)) / 2;
 		yPos = (yPos + std::min(height, static_cast<int>(bounds.y1 - bounds.y0)) / 2) * zoom;
@@ -439,7 +441,7 @@ void Viewer::zoomIn() {
 void Viewer::zoomOut() {
 	// Try to zoom out from the center
 	if (scale / zoom >= minScale) {
-		fitWidth = false;
+		fitSize = false;
 		xPos = (xPos + std::min(width, static_cast<int>(bounds.x1 - bounds.x0)) / 2) / zoom;
 		xPos -= std::min(width, static_cast<int>((bounds.x1 - bounds.x0) / zoom)) / 2;
 		yPos = (yPos + std::min(height, static_cast<int>(bounds.y1 - bounds.y0)) / 2) / zoom;

--- a/Viewer.cpp
+++ b/Viewer.cpp
@@ -116,7 +116,6 @@ const fz_rect& Document::getBounds() {
 }
 
 bool Document::gotoPage(unsigned int page){
-	printf("gotoPage(%i)\n", page);
 	if (page < getPages()) {
 		resetFind();
 		pageNo = page;
@@ -139,7 +138,6 @@ void Document::resetFind() {
 }
 
 const fz_rect* Document::find(char *s) {
-	printf("find\n");
 	if (matchingFor != nullptr && matchingFor != s){
 		// free(matchingFor);
 		matchingFor = nullptr;
@@ -293,9 +291,6 @@ void Viewer::fixBounds() {
 }
 
 void Viewer::drawPage() {
-	fz_drop_pixmap(ctx, pix);
-
-	pix = nullptr;
 
 	fz_page* page = doc->ensureCurrentPageLoaded();
 	bounds = doc->getBounds();
@@ -315,10 +310,15 @@ void Viewer::drawPage() {
 
 	fixBounds();
 
-	if (has_colors) {
-		pix = fz_new_pixmap_with_bbox(ctx, fz_device_rgb(ctx), &bbox, nullptr, 1);
-	} else {
-		pix = fz_new_pixmap_with_bbox(ctx, fz_device_gray(ctx), &bbox, nullptr, 1);
+	if (pix == nullptr || !(pix->x == bbox.x0 && pix->x + pix->w == bbox.x1 && pix->y == bbox.y0 && pix->y + pix->h == bbox.y1)) {
+		fz_drop_pixmap(ctx, pix);
+		pix = nullptr;
+
+		if (has_colors) {
+			pix = fz_new_pixmap_with_bbox(ctx, fz_device_rgb(ctx), &bbox, nullptr, 1);
+		} else {
+			pix = fz_new_pixmap_with_bbox(ctx, fz_device_gray(ctx), &bbox, nullptr, 1);
+		}
 	}
 	fz_clear_pixmap_with_value(ctx, pix, 0xff);
 

--- a/Viewer.cpp
+++ b/Viewer.cpp
@@ -25,7 +25,7 @@ extern "C" {
 #include "Screen.hpp"
 
 const int Viewer::scroll = 20;
-const float Viewer::zoom = 1.2;
+const float Viewer::zoom = 1.25;
 const unsigned char Viewer::bgColor = 103;
 const float Viewer::maxScale = 2.0;
 const float Viewer::minScale = 0.1;

--- a/Viewer.cpp
+++ b/Viewer.cpp
@@ -30,69 +30,41 @@ const unsigned char Viewer::bgColor = 103;
 const float Viewer::maxScale = 2.0;
 const float Viewer::minScale = 0.1;
 
-// We have a separate initialization method for the error handling
-Viewer::Viewer() {
-	ctx = fz_new_context(nullptr, nullptr, 16 << 20);
-	if (ctx) {
-		fz_register_document_handlers(ctx);
-	} else {
-		throw "Could not allocate MuPDF context";
-	}
-	doc = nullptr;
-	page = nullptr;
-	pix = nullptr;
-	scale = 1.0f;
-	pageNo = 0;
-	xPos = 0;
-	yPos = 0;
-	curPageLoaded = false;
-	fitWidth = true;
-	width = SCREEN_WIDTH;
-	height = SCREEN_HEIGHT;
 
-	pageText = nullptr;
-	matchesCount = 0;
-	matchIdx = -1;
+PageIterator::PageIterator(int start, int nPages, Direction dir)
+	: start{start}
+	, nPages{nPages}
+	, dir{dir}
+	, current{start}
+	{}
+
+int PageIterator::next() {
+	int newCurrent = (nPages + current + dir) % nPages;
+	if (newCurrent != start) {
+		current = newCurrent;
+		return current;
+	}
+	return -1;
 }
 
-Viewer::~Viewer() {
-	fz_drop_pixmap(ctx, pix);
-	fz_drop_page(ctx, page);
-	fz_drop_stext_page(ctx, pageText);
+Document::Document(fz_context *ctx)
+	: ctx{ctx}
+	{
+}
+
+Document::~Document(){
+	if (matchingFor != nullptr ){
+		free(matchingFor);
+		matchingFor = nullptr;
+	}
+	if (page != nullptr) {
+		fz_drop_page(ctx, page);
+		page = nullptr;
+	}
 	fz_drop_document(ctx, doc);
-	fz_drop_context(ctx);
 }
 
-void Viewer::invert(const fz_rect *rect) {
-	fz_irect b;
-	fz_rect r = *rect;
-	fz_round_rect(&b, fz_transform_rect(&r, &transform));
-	fz_invert_pixmap_rect(ctx, pix, &b);
-}
-
-bool Viewer::find(const char *s) {
-	if (matchIdx != -1)
-		invert(&matches[matchIdx]);
-	matchesCount = fz_search_stext_page(ctx, pageText, s, matches, nelem(matches));
-	matchIdx = -1;
-	return (matchesCount > 0);
-}
-
-bool Viewer::findNext(bool dir) {
-	if (matchesCount <= 0)
-		return false;
-	if (matchIdx != -1) {
-		invert(&matches[matchIdx]);
-	}
-	if (dir == 0)
-		matchIdx = (matchIdx + 1) % matchesCount;
-	else
-		matchIdx = (matchesCount + matchIdx - 1) % matchesCount;
-	invert(&matches[matchIdx]);
-	return true;
-}
-
-void Viewer::openDoc(const char *path) {
+bool Document::open(const char *path) {
 	fz_try(ctx) {
 		doc = fz_open_document(ctx, path);
 		if (fz_needs_password(ctx, doc)) {
@@ -110,13 +82,197 @@ void Viewer::openDoc(const char *path) {
 			}
 		}
 	} fz_catch(ctx) {
+		return false;
+	}
+	return true;
+}
+
+unsigned int Document::getPages() {
+	int pages = fz_count_pages(ctx, doc);
+	if (pages >= 0) return static_cast<unsigned int>(pages);
+	return 0;
+}
+
+fz_page* Document::ensureCurrentPageLoaded() {
+	if (currentlyLoadedPageNo != pageNo) {
+		if (page != nullptr) fz_drop_page(ctx, page);
+		page = fz_load_page(ctx, doc, pageNo);
+		fz_bound_page(ctx, page, &bounds);
+		currentlyLoadedPageNo = pageNo;
+	}
+	return page;
+}
+
+bool Document::next() {
+	return gotoPage(pageNo + 1);
+}
+
+bool Document::prev() {
+	return gotoPage(pageNo - 1);
+}
+
+const fz_rect& Document::getBounds() {
+	return bounds;
+}
+
+bool Document::gotoPage(unsigned int page){
+	printf("gotoPage(%i)\n", page);
+	if (page < getPages()) {
+		resetFind();
+		pageNo = page;
+		ensureCurrentPageLoaded();
+		return true;
+	}
+	return false;
+}
+
+const fz_rect* Document::getCurrentMatch() {
+	if (matchesCount > 0) {
+		return &matches[matchIdx];
+	}
+	return nullptr;
+}
+
+void Document::resetFind() {
+	matchesCount = 0;
+	matchIdx = 0;
+}
+
+const fz_rect* Document::find(char *s) {
+	printf("find\n");
+	if (matchingFor != nullptr && matchingFor != s){
+		// free(matchingFor);
+		matchingFor = nullptr;
+	}
+	matchingFor = s;
+
+	resetFind();
+	auto iter = PageIterator(pageNo, getPages(), Direction::FORWARD);
+	return gotoNextPageWithOccurrence(iter);
+}
+
+int Document::scanPages(PageIterator& iter, int* outPage){
+	int cnt = 0;
+	int page = iter.current;
+	while(page >= 0){
+		cnt = fz_search_page_number(ctx, doc, page, matchingFor, matches, MATCH_LIMIT);
+		if (cnt > 0) {
+			*outPage = page;
+			return cnt;
+		}
+		page = iter.next();
+	};
+	return 0;
+}
+
+fz_rect* Document::gotoNextPageWithOccurrence(PageIterator& iter) {
+	int foundOnPage{0};
+	int cnt = scanPages(iter, &foundOnPage);
+	if (cnt > 0) {
+		gotoPage(foundOnPage);
+		matchesCount = cnt;
+		if (iter.dir == Direction::BACKWARD) matchIdx = matchesCount - 1;
+		else matchIdx = 0;
+
+		// Sort for more intuitive ordering
+		std::sort(matches, matches + matchesCount,
+			[](const fz_rect& a, const fz_rect& b) -> bool {
+				return a.y0 < b.y0 || (a.y0 == b.y0 && a.x0 < b.x0); // prioritize y over x
+			}
+		);
+		return &matches[matchIdx];
+	}
+	return nullptr;
+}
+
+const fz_rect* Document::findNext(Direction dir) {
+	if (matchingFor){
+		if (
+			(matchIdx < matchesCount - 1 && dir == Direction::FORWARD)
+			|| 	(matchIdx > 0 && dir == Direction::BACKWARD)
+		) {
+			// Page has already been searched and more matches are available
+			matchIdx += dir;
+			return &matches[matchIdx];
+		}
+		// Look for matches on other pages.
+		auto iter = PageIterator(pageNo, getPages(), dir);
+		iter.next(); // Skip current page
+		return gotoNextPageWithOccurrence(iter);
+	}
+	return nullptr;
+}
+
+
+// We have a separate initialization method for the error handling
+Viewer::Viewer()
+	: width{SCREEN_WIDTH}
+	, height{SCREEN_HEIGHT}
+	, doc{nullptr}
+	{
+	ctx = fz_new_context(nullptr, nullptr, 16 << 20);
+	if (ctx) {
+		fz_register_document_handlers(ctx);
+	} else {
+		throw "Could not allocate MuPDF context";
+	}
+	pix = nullptr;
+	scale = 1.0f;
+	xPos = 0;
+	yPos = 0;
+	fitWidth = true;
+}
+
+Viewer::~Viewer() {
+	this->doc.reset(); // TODO: Needed as doc depends on ctx for shutdown
+	fz_drop_pixmap(ctx, pix);
+	fz_drop_context(ctx);
+}
+
+void Viewer::invertPixels(const fz_rect *rect) {
+	fz_irect b;
+	fz_rect r = *rect;
+	fz_round_rect(&b, fz_transform_rect(&r, &transform));
+	fz_invert_pixmap_rect(ctx, pix, &b);
+}
+
+
+bool Viewer::find(char *s) {
+	const fz_rect* match = doc->getCurrentMatch();
+	if (match) invertPixels(match);
+
+	match = doc->find(s);
+	if (match) {
+		ensureInView(match);
+		drawPage();
+		return true;
+	}
+	return false;
+}
+
+bool Viewer::findNext(Direction dir) {
+	const fz_rect* match = doc->getCurrentMatch();
+	if (match) invertPixels(match);
+
+	match = doc->findNext(dir);
+	if (match) {
+		drawPage();
+		return true;
+	}
+	return false;
+}
+
+void Viewer::openDoc(const char *path) {
+	auto d = std::make_unique<Document>(ctx);
+	bool success = d->open(path);
+	doc = std::move(d);
+	if (!success) {
 		show_msgbox("nPDF", "Can't open document");
-		fz_throw(ctx, FZ_ERROR_GENERIC, "can't open document");
 	}
 }
 
 int Viewer::getPages() {
-	return fz_count_pages(ctx, doc);
+	return doc->getPages();
 }
 
 void Viewer::fixBounds() {
@@ -135,18 +291,12 @@ void Viewer::fixBounds() {
 
 void Viewer::drawPage() {
 	fz_drop_pixmap(ctx, pix);
-	fz_drop_stext_page(ctx, pageText);
 
 	pix = nullptr;
-	pageText = nullptr;
 
-	if (!curPageLoaded) {
-		fz_drop_page(ctx, page);
-		page = fz_load_page(ctx, doc, pageNo);
-		curPageLoaded = true;
-	}
+	fz_page* page = doc->ensureCurrentPageLoaded();
+	bounds = doc->getBounds();
 
-	fz_bound_page(ctx, page, &bounds);
 	if (fitWidth) {
 		scale = width / (bounds.x1 - bounds.x0);
 	}
@@ -172,9 +322,8 @@ void Viewer::drawPage() {
 	fz_drop_device(ctx, dev);
 	dev = nullptr;
 
-	pageText = fz_new_stext_page_from_page(ctx, page, nullptr);
-
-	matchIdx = -1;
+	const fz_rect* match = doc->getCurrentMatch();
+	if (match) invertPixels(match);
 }
 
 void Viewer::display() {
@@ -220,18 +369,14 @@ void Viewer::display() {
 }
 
 void Viewer::next() {
-	if (pageNo < fz_count_pages(ctx, doc) - 1) {
-		pageNo++;
-		curPageLoaded = false;
+	if (doc->next()){
 		yPos = 0;
 		drawPage();
 	}
 }
 
 void Viewer::prev() {
-	if (pageNo > 0) {
-		pageNo--;
-		curPageLoaded = false;
+	if (doc->prev()){
 		yPos = 0;
 		drawPage();
 	}
@@ -247,7 +392,7 @@ void Viewer::scrollUp() {
 void Viewer::scrollDown() {
 	if (yPos < (bounds.y1 - bounds.y0) - height) {
 		yPos += scroll;
-		yPos = (yPos > (bounds.y1 - bounds.y0) - height)?(bounds.y1 - bounds.y0) - height:yPos;
+		yPos = (yPos > (bounds.y1 - bounds.y0) - height) ? (bounds.y1 - bounds.y0) - height : yPos;
 	}
 }
 
@@ -261,7 +406,7 @@ void Viewer::scrollLeft() {
 void Viewer::scrollRight() {
 	if (xPos < (bounds.x1 - bounds.x0) - width ) {
 		xPos += scroll;
-		xPos = (xPos > (bounds.x1 - bounds.x0) - width)?(bounds.x1 - bounds.x0) - width:xPos;
+		xPos = (xPos > (bounds.x1 - bounds.x0) - width) ? (bounds.x1 - bounds.x0) - width : xPos;
 	}
 }
 
@@ -301,10 +446,8 @@ void Viewer::zoomOut() {
 }
 
 void Viewer::gotoPage(unsigned int page) {
-	if (static_cast<int>(page) < fz_count_pages(ctx, doc)) {
-		pageNo = page;
-		curPageLoaded = false;
+	if (doc->gotoPage(page)){
+		yPos = 0;
 		drawPage();
 	}
-	yPos = 0;
 }

--- a/Viewer.cpp
+++ b/Viewer.cpp
@@ -25,7 +25,7 @@ extern "C" {
 #include "Screen.hpp"
 
 const int Viewer::scroll = 20;
-const float Viewer::zoom = 1.142857;
+const float Viewer::zoom = 1.2;
 const unsigned char Viewer::bgColor = 103;
 const float Viewer::maxScale = 2.0;
 const float Viewer::minScale = 0.1;

--- a/Viewer.cpp
+++ b/Viewer.cpp
@@ -271,7 +271,7 @@ void Viewer::openDoc(const char *path) {
 	bool success = d->open(path);
 	doc = std::move(d);
 	if (!success) {
-		show_msgbox("nPDF", "Can't open document");
+		throw "Can't open document.";
 	}
 }
 

--- a/Viewer.cpp
+++ b/Viewer.cpp
@@ -32,7 +32,7 @@ const float Viewer::minScale = 0.1;
 
 // We have a separate initialization method for the error handling
 Viewer::Viewer() {
-	ctx = fz_new_context(nullptr, nullptr, FZ_STORE_UNLIMITED);
+	ctx = fz_new_context(nullptr, nullptr, 16 << 20);
 	if (ctx) {
 		fz_register_document_handlers(ctx);
 	} else {

--- a/Viewer.cpp
+++ b/Viewer.cpp
@@ -234,8 +234,10 @@ void Viewer::invertPixels(const fz_rect *rect) {
 }
 
 void Viewer::ensureInView(const fz_rect *rect) {
-	if (xPos > rect->x0 || xPos + width < rect->x1) xPos = (rect->x0 + rect->x1) / 2 - width / 2;
-	if (yPos > rect->y0 || yPos + height < rect->y1) yPos = (rect->y0 + rect->y1) / 2 - height / 2;
+	if (xPos > rect->x0 * scale || xPos + width < rect->x1 * scale)
+		xPos = ((rect->x0 + rect->x1) * scale / 2.0 - width / 2.0);
+	if (yPos > rect->y0 * scale || yPos + height < rect->y1 * scale)
+		yPos = ((rect->y0 + rect->y1) * scale / 2.0 - height / 2.0);
 }
 
 bool Viewer::find(char *s) {

--- a/Viewer.cpp
+++ b/Viewer.cpp
@@ -416,13 +416,9 @@ void Viewer::scrollRight() {
 	}
 }
 
-void Viewer::setFitSize() {
-	fitSize = true;
+void Viewer::setFitSize(bool fit) {
+	fitSize = fit;
 	drawPage();
-}
-
-void Viewer::unsetFitSize() {
-	fitSize = false;
 }
 
 void Viewer::zoomIn() {

--- a/Viewer.cpp
+++ b/Viewer.cpp
@@ -236,6 +236,10 @@ void Viewer::invertPixels(const fz_rect *rect) {
 	fz_invert_pixmap_rect(ctx, pix, &b);
 }
 
+void Viewer::ensureInView(const fz_rect *rect) {
+	if (xPos > rect->x0 || xPos + width < rect->x1) xPos = (rect->x0 + rect->x1) / 2 - width / 2;
+	if (yPos > rect->y0 || yPos + height < rect->y1) yPos = (rect->y0 + rect->y1) / 2 - height / 2;
+}
 
 bool Viewer::find(char *s) {
 	const fz_rect* match = doc->getCurrentMatch();
@@ -256,6 +260,7 @@ bool Viewer::findNext(Direction dir) {
 
 	match = doc->findNext(dir);
 	if (match) {
+		ensureInView(match);
 		drawPage();
 		return true;
 	}

--- a/Viewer.hpp
+++ b/Viewer.hpp
@@ -127,8 +127,7 @@ class Viewer {
 		void scrollDown();
 		void scrollLeft();
 		void scrollRight();
-		void setFitSize();
-		void unsetFitSize();
+		void setFitSize(bool fit);
 		void zoomIn();
 		void zoomOut();
 		void gotoPage(unsigned int page);

--- a/Viewer.hpp
+++ b/Viewer.hpp
@@ -117,6 +117,7 @@ class Viewer {
 		bool find(char *s);
 		bool findNext(Direction dir);
 		void openDoc(const char *path);
+		void ensureInView(const fz_rect *rect);
 		int getPages();
 		void drawPage();
 		void display();

--- a/Viewer.hpp
+++ b/Viewer.hpp
@@ -104,7 +104,7 @@ class Viewer {
 		float scale;
 		int xPos;
 		int yPos;
-		bool fitWidth;
+		bool fitSize = true;
 		const int width;
 		const int height;
 
@@ -127,8 +127,8 @@ class Viewer {
 		void scrollDown();
 		void scrollLeft();
 		void scrollRight();
-		void setFitWidth();
-		void unsetFitWidth();
+		void setFitSize();
+		void unsetFitSize();
 		void zoomIn();
 		void zoomOut();
 		void gotoPage(unsigned int page);

--- a/main.cpp
+++ b/main.cpp
@@ -166,10 +166,10 @@ int main(int argc, char **argv) {
 					toRefresh = 1;
 				}
 				if (current & findnext) {
-					v->findNext(0);
+					v->findNext(Direction::FORWARD);
 					toRefresh = 1;
 				} else if (current & findprev) {
-					v->findNext(1);
+					v->findNext(Direction::BACKWARD);
 					toRefresh = 1;
 				}
 				if (toRefresh) {
@@ -186,18 +186,18 @@ int main(int argc, char **argv) {
 			if (isKeyPressed(KEY_NSPIRE_CTRL) && isKeyPressed(KEY_NSPIRE_TAB)) {
 				wait_no_key_pressed();
 				if (show_1numeric_input("Go to page", "", "Enter page number", &page, 1, v->getPages())) {
-					v->gotoPage(page - 1);
+					if (page > 0){
+						v->gotoPage(static_cast<unsigned int>(page - 1));
+					}
 				}
 				v->display();
 			}
 			if (isKeyPressed(KEY_NSPIRE_CTRL) && isKeyPressed(KEY_NSPIRE_F)) {
 				char *s = nullptr;
 				wait_no_key_pressed();
-				if (show_msg_user_input("Find", "Enter string to search for", "", &s) != -1) {
-					if(v->find(s)) {
-						v->findNext(0);
-					}
-					delete s;
+				int len = show_msg_user_input("Find", "Enter string to search for", "", &s);
+				if (len > 0) {
+					v->find(s);
 				}
 				v->display();
 			}

--- a/main.cpp
+++ b/main.cpp
@@ -36,7 +36,8 @@ enum ScrollAction {
 	zoomout = 64,
 	zoomin = 128,
 	findnext = 256,
-	findprev = 512
+	findprev = 512,
+	resetzoom = 1024,
 };
 
 ScrollAction operator|(ScrollAction a, ScrollAction b) {
@@ -78,6 +79,8 @@ ScrollAction getScrollKey() {
 		else
 			action |= findnext;
 	}
+	if (isKeyPressed(KEY_NSPIRE_CTRL) && isKeyPressed(KEY_NSPIRE_R))
+		action |= resetzoom;
 	return action;
 }
 
@@ -163,6 +166,9 @@ int main(int argc, char **argv) {
 					toRefresh = 1;
 				} else if (current & zoomin) {
 					v->zoomIn();
+					toRefresh = 1;
+				} else if (current & resetzoom) {
+					v->setFitSize(true);
 					toRefresh = 1;
 				}
 				if (current & findnext) {

--- a/main.cpp
+++ b/main.cpp
@@ -125,8 +125,7 @@ int main(int argc, char **argv) {
 		Viewer v{};
 		v.openDoc(argv[1]);
 
-		if(!Screen::init())
-			return 1;
+		Screen screen{};
 		Timer::init();
 		v.drawPage();
 		v.display();
@@ -213,8 +212,6 @@ int main(int argc, char **argv) {
 	} catch(const char *s) {
 		show_msgbox("nPDF", s);
 	}
-
-	Screen::deinit();
 
 	return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -16,7 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with nPDF.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <memory>
 #include <keys.h>
 #include <libndls.h>
 #include <string>
@@ -123,15 +122,14 @@ int main(int argc, char **argv) {
 	}
 
 	try {
-		std::unique_ptr<Viewer> v = std::make_unique<Viewer>();
-		v.reset(new Viewer);
-		v->openDoc(argv[1]);
+		Viewer v{};
+		v.openDoc(argv[1]);
 
 		if(!Screen::init())
 			return 1;
 		Timer::init();
-		v->drawPage();
-		v->display();
+		v.drawPage();
+		v.display();
 
 		ScrollAction lastScrollKey = none;
 		ScrollAction current = none;
@@ -143,46 +141,46 @@ int main(int argc, char **argv) {
 				if (current != lastScrollKey || Timer::done()) {
 					toRefresh = false;
 					if (current & down) {
-						v->scrollDown();
+						v.scrollDown();
 						toRefresh = 1;
 					} else if (current & up) {
-						v->scrollUp();
+						v.scrollUp();
 						toRefresh = 1;
 					}
 					if (current & right) {
-						v->scrollRight();
+						v.scrollRight();
 						toRefresh = 1;
 					} else if (current & left) {
-						v->scrollLeft();
+						v.scrollLeft();
 						toRefresh = 1;
 					}
 					if (current & pgdown) {
-						v->next();
+						v.next();
 						toRefresh = 1;
 					} else if (current & pgup) {
-						v->prev();
+						v.prev();
 						toRefresh = 1;
 					}
 					if (current & zoomout) {
-						v->zoomOut();
+						v.zoomOut();
 						toRefresh = 1;
 					} else if (current & zoomin) {
-						v->zoomIn();
+						v.zoomIn();
 						toRefresh = 1;
 					} else if (current & resetzoom) {
-						v->setFitSize(true);
+						v.setFitSize(true);
 						toRefresh = 1;
 					}
 					if (current & findnext) {
-						v->findNext(Direction::FORWARD);
+						v.findNext(Direction::FORWARD);
 						toRefresh = 1;
 					} else if (current & findprev) {
-						v->findNext(Direction::BACKWARD);
+						v.findNext(Direction::BACKWARD);
 						toRefresh = 1;
 					}
 					if (toRefresh) {
 						handleDelays(current, lastScrollKey);
-						v->display();
+						v.display();
 					}
 				}
 			} else {
@@ -193,21 +191,21 @@ int main(int argc, char **argv) {
 				}
 				if (isKeyPressed(KEY_NSPIRE_CTRL) && isKeyPressed(KEY_NSPIRE_TAB)) {
 					wait_no_key_pressed();
-					if (show_1numeric_input("Go to page", "", "Enter page number", &page, 1, v->getPages())) {
+					if (show_1numeric_input("Go to page", "", "Enter page number", &page, 1, v.getPages())) {
 						if (page > 0){
-							v->gotoPage(static_cast<unsigned int>(page - 1));
+							v.gotoPage(static_cast<unsigned int>(page - 1));
 						}
 					}
-					v->display();
+					v.display();
 				}
 				if (isKeyPressed(KEY_NSPIRE_CTRL) && isKeyPressed(KEY_NSPIRE_F)) {
 					char *s = nullptr;
 					wait_no_key_pressed();
 					int len = show_msg_user_input("Find", "Enter search string", "", &s);
 					if (len > 0) {
-						v->find(s);
+						v.find(s);
 					}
-					v->display();
+					v.display();
 				}
 			}
 			msleep(10);

--- a/main.cpp
+++ b/main.cpp
@@ -93,122 +93,127 @@ void handleDelays(ScrollAction key, ScrollAction& lastScrollKey) {
 	}
 }
 
-int main(int argc, char **argv) {
-	std::unique_ptr<Viewer> v;
-	try {
-		v.reset(new Viewer);
-	} catch(const char *s) {
-		show_msgbox("nPDF", s);
-		return 1;
+void registerExtensions(char* executable) {
+	std::string s = std::string(executable);
+	size_t pos = s.find_last_of("/");
+	if (pos != std::string::npos) {
+		s.erase(0, s.find_last_of("/") + 1);
 	}
+	if (s.size() >= 4 && s.substr(s.size() - 4) == ".tns") {
+		s.erase(s.size() - 4);
+	}
+	cfg_register_fileext("pdf", s.c_str());
+	cfg_register_fileext("xps", s.c_str());
+	cfg_register_fileext("cbz", s.c_str());
+	cfg_register_fileext("xml", s.c_str());
+	cfg_register_fileext("xhtml", s.c_str());
+	cfg_register_fileext("html", s.c_str());
+	cfg_register_fileext("htm", s.c_str());
+	cfg_register_fileext("epub", s.c_str());
+	show_msgbox("nPDF", "File extensions registered. You can now open a .pdf, .xps, .cbz, .xml, .xhtml, .html, .htm and .epub files from the Documents screen");
+}
 
-	if (argc >= 2) {
-		v->openDoc(argv[1]);
-	} else if (argc >= 1) {
-		std::string s = std::string(argv[0]);
-		size_t pos = s.find_last_of("/");
-		if (pos != std::string::npos) {
-			s.erase(0, s.find_last_of("/") + 1);
-		}
-		if (s.size() >= 4 && s.substr(s.size() - 4) == ".tns") {
-			s.erase(s.size() - 4);
-		}
-		cfg_register_fileext("pdf", s.c_str());
-		cfg_register_fileext("xps", s.c_str());
-		cfg_register_fileext("cbz", s.c_str());
-		cfg_register_fileext("xml", s.c_str());
-		cfg_register_fileext("xhtml", s.c_str());
-		cfg_register_fileext("html", s.c_str());
-		cfg_register_fileext("htm", s.c_str());
-		cfg_register_fileext("epub", s.c_str());
-		show_msgbox("nPDF", "File extensions registered. You can now open a .pdf, .xps, .cbz, .xml, .xhtml, .html, .htm and .epub files from the Documents screen");
+int main(int argc, char **argv) {
+	if (argc == 0) {
+		show_msgbox("nPDF", "Executable called with no arguments. Exiting.");
+		return 1;
+	} else if (argc == 1) {
+		registerExtensions(argv[0]);
 		return 0;
 	}
 
-	if(!Screen::init())
-		return 1;
-	Timer::init();
-	v->drawPage();
-	v->display();
+	try {
+		std::unique_ptr<Viewer> v = std::make_unique<Viewer>();
+		v.reset(new Viewer);
+		v->openDoc(argv[1]);
 
-	ScrollAction lastScrollKey = none;
-	ScrollAction current = none;
+		if(!Screen::init())
+			return 1;
+		Timer::init();
+		v->drawPage();
+		v->display();
 
-	int page;
-	bool toRefresh;
-	while (true) {
-		if ((current = getScrollKey())) {
-			if (current != lastScrollKey || Timer::done()) {
-				toRefresh = false;
-				if (current & down) {
-					v->scrollDown();
-					toRefresh = 1;
-				} else if (current & up) {
-					v->scrollUp();
-					toRefresh = 1;
+		ScrollAction lastScrollKey = none;
+		ScrollAction current = none;
+
+		int page;
+		bool toRefresh;
+		while (true) {
+			if ((current = getScrollKey())) {
+				if (current != lastScrollKey || Timer::done()) {
+					toRefresh = false;
+					if (current & down) {
+						v->scrollDown();
+						toRefresh = 1;
+					} else if (current & up) {
+						v->scrollUp();
+						toRefresh = 1;
+					}
+					if (current & right) {
+						v->scrollRight();
+						toRefresh = 1;
+					} else if (current & left) {
+						v->scrollLeft();
+						toRefresh = 1;
+					}
+					if (current & pgdown) {
+						v->next();
+						toRefresh = 1;
+					} else if (current & pgup) {
+						v->prev();
+						toRefresh = 1;
+					}
+					if (current & zoomout) {
+						v->zoomOut();
+						toRefresh = 1;
+					} else if (current & zoomin) {
+						v->zoomIn();
+						toRefresh = 1;
+					} else if (current & resetzoom) {
+						v->setFitSize(true);
+						toRefresh = 1;
+					}
+					if (current & findnext) {
+						v->findNext(Direction::FORWARD);
+						toRefresh = 1;
+					} else if (current & findprev) {
+						v->findNext(Direction::BACKWARD);
+						toRefresh = 1;
+					}
+					if (toRefresh) {
+						handleDelays(current, lastScrollKey);
+						v->display();
+					}
 				}
-				if (current & right) {
-					v->scrollRight();
-					toRefresh = 1;
-				} else if (current & left) {
-					v->scrollLeft();
-					toRefresh = 1;
+			} else {
+				lastScrollKey = none;
+				Timer::stop();
+				if (isKeyPressed(KEY_NSPIRE_ESC)) {
+					break;
 				}
-				if (current & pgdown) {
-					v->next();
-					toRefresh = 1;
-				} else if (current & pgup) {
-					v->prev();
-					toRefresh = 1;
+				if (isKeyPressed(KEY_NSPIRE_CTRL) && isKeyPressed(KEY_NSPIRE_TAB)) {
+					wait_no_key_pressed();
+					if (show_1numeric_input("Go to page", "", "Enter page number", &page, 1, v->getPages())) {
+						if (page > 0){
+							v->gotoPage(static_cast<unsigned int>(page - 1));
+						}
+					}
+					v->display();
 				}
-				if (current & zoomout) {
-					v->zoomOut();
-					toRefresh = 1;
-				} else if (current & zoomin) {
-					v->zoomIn();
-					toRefresh = 1;
-				} else if (current & resetzoom) {
-					v->setFitSize(true);
-					toRefresh = 1;
-				}
-				if (current & findnext) {
-					v->findNext(Direction::FORWARD);
-					toRefresh = 1;
-				} else if (current & findprev) {
-					v->findNext(Direction::BACKWARD);
-					toRefresh = 1;
-				}
-				if (toRefresh) {
-					handleDelays(current, lastScrollKey);
+				if (isKeyPressed(KEY_NSPIRE_CTRL) && isKeyPressed(KEY_NSPIRE_F)) {
+					char *s = nullptr;
+					wait_no_key_pressed();
+					int len = show_msg_user_input("Find", "Enter search string", "", &s);
+					if (len > 0) {
+						v->find(s);
+					}
 					v->display();
 				}
 			}
-		} else {
-			lastScrollKey = none;
-			Timer::stop();
-			if (isKeyPressed(KEY_NSPIRE_ESC)) {
-				break;
-			}
-			if (isKeyPressed(KEY_NSPIRE_CTRL) && isKeyPressed(KEY_NSPIRE_TAB)) {
-				wait_no_key_pressed();
-				if (show_1numeric_input("Go to page", "", "Enter page number", &page, 1, v->getPages())) {
-					if (page > 0){
-						v->gotoPage(static_cast<unsigned int>(page - 1));
-					}
-				}
-				v->display();
-			}
-			if (isKeyPressed(KEY_NSPIRE_CTRL) && isKeyPressed(KEY_NSPIRE_F)) {
-				char *s = nullptr;
-				wait_no_key_pressed();
-				int len = show_msg_user_input("Find", "Enter string to search for", "", &s);
-				if (len > 0) {
-					v->find(s);
-				}
-				v->display();
-			}
+			msleep(10);
 		}
-		msleep(10);
+	} catch(const char *s) {
+		show_msgbox("nPDF", s);
 	}
 
 	Screen::deinit();

--- a/main.cpp
+++ b/main.cpp
@@ -202,7 +202,7 @@ int main(int argc, char **argv) {
 				v->display();
 			}
 		}
-		sleep(10);
+		msleep(10);
 	}
 
 	Screen::deinit();

--- a/mupdf/Makethird
+++ b/mupdf/Makethird
@@ -569,9 +569,9 @@ $(LCMS2_OUT):
 $(LCMS2_OUT)/%.o: $(LCMS2_DIR)/src/%.c | $(LCMS2_OUT)
 	$(CC_CMD) -I$(LCMS2_DIR)/include
 
-LCMS2_CFLAGS := -I$(LCMS2_DIR)/include
+LCMS2_CFLAGS := -I$(LCMS2_DIR)/include -DCMS_NO_PTHREADS
 else
-LCMS2_CFLAGS := -DNO_ICC
+LCMS2_CFLAGS := -DNO_ICC -DCMS_NO_PTHREADS
 endif
 
 # --- cURL ---

--- a/mupdf/source/fitz/color-lcms.c
+++ b/mupdf/source/fitz/color-lcms.c
@@ -1,8 +1,8 @@
 #include "mupdf/fitz.h"
 
 #ifndef NO_ICC
-#include "lcms2art.h"
-#include "lcms2art_plugin.h"
+#include "lcms2mt.h"
+#include "lcms2mt_plugin.h"
 #include "colorspace-imp.h"
 
 #define LCMS_BYTES_MASK 0x7
@@ -225,7 +225,7 @@ fz_lcms_init_link(fz_cmm_instance *instance, fz_icclink *link, const fz_iccprofi
 
 	if (prf == NULL)
 	{
-		link->cmm_handle = cmsCreateTransformTHR(cmm_ctx, src->cmm_handle, src_data_type, dst->cmm_handle, des_data_type, rend->ri, flag);
+		link->cmm_handle = cmsCreateTransform(cmm_ctx, src->cmm_handle, src_data_type, dst->cmm_handle, des_data_type, rend->ri, flag);
 		if (!link->cmm_handle)
 			fz_throw(ctx, FZ_ERROR_GENERIC, "cmsCreateTransform failed");
 	}
@@ -236,13 +236,13 @@ fz_lcms_init_link(fz_cmm_instance *instance, fz_icclink *link, const fz_iccprofi
 		 */
 		if (src == prf)
 		{
-			link->cmm_handle = cmsCreateTransformTHR(cmm_ctx, src->cmm_handle, src_data_type, dst->cmm_handle, des_data_type, INTENT_RELATIVE_COLORIMETRIC, flag);
+			link->cmm_handle = cmsCreateTransform(cmm_ctx, src->cmm_handle, src_data_type, dst->cmm_handle, des_data_type, INTENT_RELATIVE_COLORIMETRIC, flag);
 			if (!link->cmm_handle)
 				fz_throw(ctx, FZ_ERROR_GENERIC, "cmsCreateTransform failed");
 		}
 		else if (prf == dst)
 		{
-			link->cmm_handle = cmsCreateTransformTHR(cmm_ctx, src->cmm_handle, src_data_type, prf->cmm_handle, des_data_type, rend->ri, flag);
+			link->cmm_handle = cmsCreateTransform(cmm_ctx, src->cmm_handle, src_data_type, prf->cmm_handle, des_data_type, rend->ri, flag);
 			if (!link->cmm_handle)
 				fz_throw(ctx, FZ_ERROR_GENERIC, "cmsCreateTransform failed");
 		}
@@ -262,7 +262,7 @@ fz_lcms_init_link(fz_cmm_instance *instance, fz_icclink *link, const fz_iccprofi
 				lcms_prf_cs = 0;
 			prf_num_chan = cmsChannelsOf(cmm_ctx, prf_cs);
 			prf_data_type = (COLORSPACE_SH(lcms_prf_cs) | CHANNELS_SH(prf_num_chan) | BYTES_SH(num_bytes));
-			src_to_prf_link = cmsCreateTransformTHR(cmm_ctx, src->cmm_handle, src_data_type, prf->cmm_handle, prf_data_type, rend->ri, flag);
+			src_to_prf_link = cmsCreateTransform(cmm_ctx, src->cmm_handle, src_data_type, prf->cmm_handle, prf_data_type, rend->ri, flag);
 			if (!src_to_prf_link)
 				fz_throw(ctx, FZ_ERROR_GENERIC, "cmsCreateTransform failed");
 			src_to_prf_profile = cmsTransform2DeviceLink(cmm_ctx, src_to_prf_link, 3.4, flag);
@@ -273,7 +273,7 @@ fz_lcms_init_link(fz_cmm_instance *instance, fz_icclink *link, const fz_iccprofi
 			hProfiles[0] = src_to_prf_profile;
 			hProfiles[1] = prf->cmm_handle;
 			hProfiles[2] = dst->cmm_handle;
-			link->cmm_handle = cmsCreateMultiprofileTransformTHR(cmm_ctx, hProfiles, 3, src_data_type, des_data_type, INTENT_RELATIVE_COLORIMETRIC, flag);
+			link->cmm_handle = cmsCreateMultiprofileTransform(cmm_ctx, hProfiles, 3, src_data_type, des_data_type, INTENT_RELATIVE_COLORIMETRIC, flag);
 			cmsCloseProfile(cmm_ctx, src_to_prf_profile);
 			if (!link->cmm_handle)
 				fz_throw(ctx, FZ_ERROR_GENERIC, "cmsCreateMultiprofileTransform failed");
@@ -302,7 +302,7 @@ fz_lcms_new_instance(fz_context *ctx)
 	DEBUG_LCMS_MEM(("Context Creation:: mupdf ctx = %p lcms ctx = %p \n", (void*) ctx, (void*) cmm_ctx));
 	if (cmm_ctx == NULL)
 		fz_throw(ctx, FZ_ERROR_GENERIC, "cmsCreateContext failed");
-	cmsSetLogErrorHandlerTHR(cmm_ctx, fz_lcms_log_error);
+	cmsSetLogErrorHandler(cmm_ctx, fz_lcms_log_error);
 	return (fz_cmm_instance *)cmm_ctx;
 }
 
@@ -326,7 +326,7 @@ fz_lcms_init_profile(fz_cmm_instance *instance, fz_iccprofile *profile)
 	DEBUG_LCMS_MEM(("@@@@@@@ Create Profile Start:: mupdf ctx = %p lcms ctx = %p \n", (void*)ctx, (void*)cmm_ctx));
 
 	size = fz_buffer_storage(ctx, profile->buffer, &data);
-	profile->cmm_handle = cmsOpenProfileFromMemTHR(cmm_ctx, data, (cmsUInt32Number)size);
+	profile->cmm_handle = cmsOpenProfileFromMem(cmm_ctx, data, (cmsUInt32Number)size);
 	if (profile->cmm_handle == NULL)
 	{
 		profile->num_devcomp = 0;


### PR DESCRIPTION
## Cross-page search
- Pressing "Ctrl+G" on the last occurrence of a page (or first, if going in reverse), searches the next page until an entry is found
- If the end of the document is reached (or the beginning), the search loops around to the other end
- If there are no entries in the document, the search stops once every page has been checked

This addresses #25 and part of #17

## Zoom reset shortcut
- Pressing "Ctrl+R" resets the zoom to fit the whole page

## Dependency updates
- Some of the dependencies could no longer be fetched, I suspect the commits were taken down
This addresses issue #22

## Other improvements
- Implement #20, addressing #14
- Slightly speed up page switching by avoiding re-allocation of pixmap when possible
- Refactor Screen to use a singleton class, calling `deinit()` on deallocation
- Split up `Viewer` into `Viewer`, `Document` and `PageIterator` for better separation of concerns
- Refactored `main()` to better deal with exceptions
- Increase zoom factor to 1.25 in order to avoid excessive waiting since zooming in and out is one of the slowest processes
- Fix coordinate mixup leading to undefined memory being displayed below the bottom edge of the document on landscape documents
- Make default view fit the document vertically, on top of horizontally (feedback more than welcome)

If want me to change/add/remove something, just let me know. I kind of got carried away :)